### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,30 @@ jobs:
         java-version: '21'
         cache: 'maven'
 
-    - name: checkout repo
-      uses: actions/checkout@main
 
     - name: Set up environment variables
       env:
         GITHUB_TOKEN: ${{ secrets.READ_PACKAGE_TOKEN_FOR_WORKFLOWS }}
       run: echo "GITHUB_TOKEN is set to access private packages"
+
+    # Add a step to create Maven settings with the GitHub token
+    - name: Setup Maven Settings
+      run: |
+        mkdir -p ~/.m2
+        cat <<EOF > ~/.m2/settings.xml
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+        http://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>github</id>
+              <username>${{ secrets.READ_PACKAGE_USER_FOR_WORKFLOWS }}</username>
+              <password>${{ secrets.READ_PACKAGE_TOKEN_FOR_WORKFLOWS }}</password>
+            </server>
+          </servers>
+        </settings>
+        EOF
 
     - name: Install dependencies
       run: make build


### PR DESCRIPTION
I'll make a fresh attempt to create a settings.xml for our Github repository. This setup should allow Maven to access the private GitHub package using the provided token during the build process without needing any changes to your local development environment.

In addition, removed a step that was duplicated because the checkout action was already present.