### PR TITLE
Library name change in literate octo guacamole

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -60,6 +60,7 @@
             <version>3.5.3</version>
         </dependency>
 
+
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -67,8 +68,6 @@
             <version>3.5.3</version>
             <scope>test</scope>
         </dependency>
-
-
 
 
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa -->
@@ -92,6 +91,7 @@
             <artifactId>algorithm-hash-extraction</artifactId>
             <version>1.0</version>
         </dependency>
+
 
     </dependencies>
 

--- a/File-Integrity-Scanner/src/test/java/org/pwss/file_integrity_scanner/PWSSLibraryTest.java
+++ b/File-Integrity-Scanner/src/test/java/org/pwss/file_integrity_scanner/PWSSLibraryTest.java
@@ -1,8 +1,8 @@
 package org.pwss.file_integrity_scanner;
 
-import lib.pwss.cryptographic_algorithm.hash.FileHashHandler;
-import lib.pwss.cryptographic_algorithm.hash.compare.util.HashCompareUtil;
-import lib.pwss.cryptographic_algorithm.hash.model.HashForFilesOutput;
+import lib.pwss.hash.FileHashHandler;
+import lib.pwss.hash.compare.util.HashCompareUtil;
+import lib.pwss.hash.model.HashForFilesOutput;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- Changed artifact namn and group id for the hash and algorithm switching library!

- The cryptographic algorithm version 1.5.2 is almost identical to version 1.0 of algorithm-hash-extraction.  The changes are in the package structure (removed redundancy) and of course the name change. The code is unchanged.