### PR TITLE
Sync master  with develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "master,develop" ]
+    branches: [ "master", "develop" ]
   pull_request:
-    branches: [ "master,develop" ]
+    branches: [ "master", "develop" ]
 
 jobs:
   build:


### PR DESCRIPTION
It's essential to prevent the develop branch from being behind the Master branch in commits