### PR TITLE
Start stop scheduled monitoring of active scan tasks

### DIFF
--- a/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/config/AppConfig.java
+++ b/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/config/AppConfig.java
@@ -7,10 +7,12 @@ import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @EnableAsync
 @EnableScheduling
@@ -37,6 +39,22 @@ public class AppConfig implements AsyncConfigurer {
             log.error("Exception in method: {}", method.getName());
             throwable.printStackTrace();
         };
+    }
+
+    /**
+     * Creates and configures a TaskScheduler bean.
+     * <p>
+     * This method provides a ThreadPoolTaskScheduler instance, which is used
+     * for scheduling tasks in a multithreaded environment.
+     *
+     * @return a configured instance of ThreadPoolTaskScheduler
+     */
+    @Bean(name = "threadPoolTaskScheduler")
+    public TaskScheduler threadPoolTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setThreadNamePrefix("MySchedulerThread-");
+        scheduler.setRejectedExecutionHandler((r, executor) -> log.warn("Scheduling rejected: task={}, executor={}", r, executor));
+        return scheduler;
     }
 
     /**


### PR DESCRIPTION
Let's scrap the old PR, I've copied my code to a new branch based off from develop after your merge of the endpoints :)
I found it to be the easiest way to manage the conflicts. 

This pull request introduces a scheduled task monitoring system for scan tasks in the file integrity scanner. It adds a configurable `TaskScheduler` bean and refactors scan monitoring logic to use a scheduled task instead of the previous `@Scheduled` annotation. Monitoring now starts and stops dynamically with scan operations, improving resource management and flexibility.

**Task Scheduling and Monitoring Improvements:**

* Added a `ThreadPoolTaskScheduler` bean to `AppConfig`, allowing for scheduled tasks to be managed in a thread pool. [[1]](diffhunk://#diff-d9bf8b5e08f4e8f28335e1bc2f58bc9c3303639abdd8bdab1cab6af0d8853012R10-R15) [[2]](diffhunk://#diff-d9bf8b5e08f4e8f28335e1bc2f58bc9c3303639abdd8bdab1cab6af0d8853012R44-R59)
* Injected the `TaskScheduler` into `ScanServiceImpl` and used it to schedule the scan monitoring task dynamically when scans start. [[1]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fR61-R65) [[2]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fL80-R86) [[3]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fR97)
* Implemented `startMonitoring()` and `stopMonitoring()` methods in `ScanServiceImpl` to control the lifecycle of the monitoring task, starting it when scans begin and stopping it when all scans are complete. [[1]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fR132-R138) [[2]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fR165) [[3]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fR216-R258) [[4]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fR362-R368)

**Scan Task Lifecycle Handling:**

* Refactored `monitorOngoingScanTasks()` to be a private method scheduled at a fixed rate, and improved logging for better traceability.
* Ensured that scan tasks are properly removed from the active task map in case of interruptions or execution exceptions, preventing resource leaks.

These changes make scan monitoring more robust and responsive to the actual state of scan operations, while also improving thread management and error handling.