### PR TITLE
Securing Tomcat-Embed-Core Dependency

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="http://maven.apache.org/POM/4.0.0"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -47,18 +48,37 @@
 
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <java.version>21</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.embed.core.version>11.0.10</tomcat.embed.core.version>
+        <spring-boot.version>4.0.0-M1</spring-boot.version>
+        <postgresql.JDBC-Driver.version>42.7.7</postgresql.JDBC-Driver.version>
     </properties>
 
+
     <dependencies>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat.embed.core.version}</version>
+        </dependency>
 
 
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-web -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>4.0.0-M1</version>
+            <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
 
@@ -66,7 +86,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>4.0.0-M1</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -77,20 +97,21 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>4.0.0-M1</version>
+            <version>${spring-boot.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.7</version>
+            <version>${postgresql.JDBC-Driver.version}</version>
         </dependency>
 
-            <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security -->
+        <!--
+        https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>4.0.0-M1</version>
+            <version>${spring-boot.version}</version>
         </dependency>
 
 
@@ -112,13 +133,28 @@
 
     <build>
         <plugins>
-
             <!--
             https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-maven-plugin -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>4.0.0-M1</version>
+                <version>${spring-boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/config/SecurityConfig.java
+++ b/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
 
     @Autowired
     private UserServiceImpl userService;
-  
+
     @Bean
     public AuthenticationManager authenticationManager(
             UserDetailsService userDetailsService,
@@ -47,8 +47,6 @@ public class SecurityConfig {
         return new ProviderManager(provider);
     }
 
-  
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, PasswordEncoder passwordEncoder) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
@@ -57,6 +55,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE).hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET).permitAll()
                         .requestMatchers(HttpMethod.POST).permitAll()
+                        .requestMatchers("/css/**").denyAll()
+                        .requestMatchers("/js/**").denyAll()
+                        .requestMatchers("/img/**").denyAll()
+                        .requestMatchers("/lib/**").denyAll()
+                        .requestMatchers("/favicon.ico").permitAll()
                         .requestMatchers("/api/file-integrity").hasRole("AUTHORIZED")
                         .anyRequest()
                         .permitAll())
@@ -66,12 +69,6 @@ public class SecurityConfig {
                 .httpBasic(Customizer.withDefaults());
 
         return http.build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.debug(false).ignoring().requestMatchers("/css/**", "/js/**", "/img/**", "/lib/**",
-                "/favicon.ico");
     }
 
     @Bean

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,43 @@
 # Define the pom directory path
 POM_DIR := File-Integrity-Scanner
 
-# Default target - nothing to do here, but it helps users
+# Default Target - nothing to do here, but it helps users
 .PHONY: all
 all:
 	@echo "Please use 'make build' to build the project."
 
-# Build target
+# Build Target
 .PHONY: build
 build:
 	cd $(POM_DIR) && mvn clean install
 
-# Test target
+# Test Target
 .PHONY: test
 test:
 	cd $(POM_DIR) && mvn clean test
 
-# Clean target
+# Clean Target
 .PHONY: clean
 clean:
 	cd $(POM_DIR) && mvn clean
 
-# Start target
+# Start Target
 .PHONY: start
 start:
 	cd $(POM_DIR) && mvn spring-boot:run
+
+# Create Artifact
+.PHONY: artifact
+artifact: build
+	cd $(POM_DIR) && mvn clean package
 
 # Help target
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  make build	- Build the project using Maven"
-	@echo "  make test	- Test the project using Maven"
-	@echo "  make clean	- Clean the project using Maven"
-	@echo "  make start	- Start the project using Maven"
-	@echo "  make help	- Display this help message"
+	@echo "  make build	  - Build the project using Maven"
+	@echo "  make test	  - Test the project using Maven"
+	@echo "  make clean	  - Clean the project using Maven"
+	@echo "  make start	  - Start the project using Maven"
+	@echo "  make artifact  - Create FIS artifact using Maven"
+	@echo "  make help	  - Display this help message"


### PR DESCRIPTION
# Securing Tomcat-Embed-Core Dependency

This PR addresses a security vulnerability by updating and properly managing our `tomcat-embed-core` dependency.

## Changes Made:
1. Updated the `tomcat-embed-core` dependency to version 11.0.10.
2. Excluded the `tomcat-embed-core` dependency from `spring-boot-starter-web` to prevent conflicts with the newer
version we're using.
3. Added `sourceEncoding` to the `pom.xml`, explicitly set to "UTF-8".
4. Introduced version variables in `pom.xml` for easier management of dependency versions.
5. Added a build plugin to repackage the JAR with all dependencies and set the `Main-Class` attribute.
6. Added a new Make target for creating artifacts:
   ```
   make artifact
   ```
7. Removed warning logs when starting the Spring app by addressing path filtering issues.

## Notes:
After making these changes, please monitor the behavior of our Spring application for any potential issues that
might arise due to the exclusion of the dependency. Based on my understanding, using Maven's exclude feature
should generally ensure compatibility with the latest versions unless there are specific methods in the vulnerable
version that do not exist in the updated version.

If an error occurs, it could be challenging to trace back. Therefore, we'll keep an eye out and plan to update to
new Spring releases as they become available, at which point we can remove the exclusion tag altogether.

We're grateful for both Spring and Tomcat's excellent security practices. The vulnerability is with Tomcat, but
they've provided an updated version promptly, demonstrating their commitment to maintaining high-quality software.
Both projects have top-notch teams and developers who generously share their code with us—our appreciation goes
out to them! 🙏

---

# Fixing the Issue with the Artifact JAR

The problem arises because the current configuration of the File-Integrity-Scanner POM does not specify how to include this information
correctly when building the JAR.

[Link to the code line where the artifact fix was made](https://github.com/pwssOrg/File-Integrity-Scanner/blob/95bdf70a76d78266c7a5e2e46f7b928ae5ccd2d3/File-Integrity-Scanner/pom.xml#L145)

---

# A photo of the SCA Scan status before this PR

<img width="1389" height="545" alt="image" src="https://github.com/user-attachments/assets/82050d13-06a9-4dd0-bc39-696ce2831f99" />
