### PR TITLE
268 enfore https for file integrity scanner

### DIFF
--- a/File-Integrity-Scanner/src/main/resources/application.yaml
+++ b/File-Integrity-Scanner/src/main/resources/application.yaml
@@ -27,6 +27,8 @@ server:
     key-store-type: PKCS12
     key-store: classpath:keystore.pkcs8.p12 ## We make as new one for production (Server Certificate)
     key-store-password: ${ssl_file_integrity_scanner}
+    enabled: true
+    http-port: -1
 directory:
       endpoint-code: 4350345983458934 # It is possible to use an environment variable if required: ${ENDPOINT_CODE_1}
   


### PR DESCRIPTION
Setting `server.http-port=-1` in application properties will effectively disable HTTP
completely, enforcing that only HTTPS connections are accepted.

Here's why:

- `server.port=15400`: This sets the port for HTTPS (since SSL/TLS is enabled).
- `server.ssl.enabled=true`: This enables SSL/TLS support.
- `server.http-port=-1`: Setting HTTP port to `-1` disables the default HTTP connector.

With these configurations:
1. The application will only listen on port 15400 for HTTPS traffic.
2. Any attempt to connect via HTTP (typically on port 80 or another non-SSL port) will fail because there's no
HTTP listener configured.

So yes, this setup enforces the use of HTTPS by disabling HTTP completely  💫 