### PR TITLE
Improve scanning workflow

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.pwss</groupId>
     <artifactId>File-Integrity-Scanner</artifactId>
-    <version>1.8</version>
+    <version>1.8.1</version>
     <packaging>jar</packaging>
     <description>A File Integrity Scanner</description>
     <licenses>


### PR DESCRIPTION
---

## Summary

This PR improves performance and clarity in the scanning workflow by removing overly verbose log statements, tightening directory filtering, and enhancing how diff information is delivered to the GUI during large scans.

## What’s Changed

### 🔧 Logging & Code Clarity

* Removed beneficial but high-frequency log statements that caused significant overhead during large scans (e.g., ~100k files).
  *These logs can still be re-added in development environments if deeper debugging is required.*
* Replaced certain logs with descriptive code comments, e.g.
  `// No existing checksum found for file from prior scans`
* Documented the future workflow: logs indicating whether a file is new or previously scanned can be restored when revisiting scan logic, but are currently too costly for production use.

### 📁 Directory & Scan Handling

* Added filtering to ensure monitored directories only include paths that actually exist on the filesystem.
* Updated the live-feed text to improve clarity when a scan contains more than 10k files.

### 🖥️ GUI Improvements

* Added diff information to the live feed so the GUI can retrieve accurate diff counts even during large scans with >10k files.

## Motivation

These adjustments significantly reduce scan overhead, prevent unnecessary log flooding, and provide cleaner and more reliable live scan data to the GUI. This leads to better performance, more predictable output, and an improved user experience during large-scale directory scans.

## Testing

* Verified scans with and without large file counts (>10k, >100k).
* Confirmed that GUI now receives correct diff data through the live feed.
* Ensured no performance regressions after removing spammy logs.

---
