### PR TITLE
The Hash Exctractor library was upgraded to version 1.2.5

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>lib.pwss</groupId>
             <artifactId>algorithm-hash-extraction</artifactId>
-            <version>1.2.4</version>
+            <version>1.2.5</version>
         </dependency>
 
 


### PR DESCRIPTION
Scanning Sys32 folder

### Test Case 1
- START TIME = 21:19:39
- END TIME = 21:24:02
- Time Difference = **4 minutes and 23 seconds**

### Test Case 2
- START TIME = 21:27:27
- END TIME = 21:31:46
- Time Difference = **4 minutes and 19 seconds**


So indeed, the second test case was **4 seconds faster** than the first one.