### PR TITLE
Upgrade Spring Boot from 4.0.0 to 4.0.1

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.pwss</groupId>
     <artifactId>File-Integrity-Scanner</artifactId>
-    <version>1.8.2</version>
+    <version>1.8.3</version>
     <packaging>jar</packaging>
     <description>A File Integrity Scanner</description>
     <licenses>
@@ -52,7 +52,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-boot.version>4.0.0</spring-boot.version>
+        <spring-boot.version>4.0.1</spring-boot.version>
         <postgresql.JDBC-Driver.version>42.7.8</postgresql.JDBC-Driver.version>
     </properties>
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ or desired, ensuring full control over data integrity for the end-user.
 
 ### Spring Version
 
-**Spring 4.0.0**
+**Spring 4.0.1**
 
 ### Steps
 


### PR DESCRIPTION
## Summary

This pull request updates the Spring Boot version from **4.0.0** to **4.0.1**.  
The upgrade was performed by bumping the Spring Boot version number in the project’s `pom.xml` file.

## Motivation

Keeping Spring Boot up to date ensures improved stability, bug fixes, and dependency upgrades in our project. Spring Boot **4.0.1** is a patch release that includes bug fixes, documentation improvements, and dependency updates compared to **4.0.0**. 

## Changes

- Updated the Spring Boot version in `pom.xml`  
  - **4.0.0 → 4.0.1**
- No application code changes were required
- Project builds successfully with the updated Spring Boot version

## What’s New in Spring Boot 4.0.1

Spring Boot **4.0.1** is primarily a patch release focusing on:
- Fixing bugs identified since the release of 4.0.0
- Documentation improvements
- Dependency upgrades  

**No major breaking changes are expected in this patch version.** 

For full details, see the official Spring Boot release announcement:  
https://spring.io/blog/2025/12/18/spring-boot-4-0-1-available-now

## Verification

- Verified that the project builds successfully with Spring Boot 4.0.1
- Existing functionality remains unchanged