### PR TITLE
Bump versions for several PWSS libraries

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>lib.pwss</groupId>
             <artifactId>algorithm-hash-extraction</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.6</version>
         </dependency>
 
 
@@ -152,14 +152,14 @@
         <dependency>
             <groupId>lib.pwss</groupId>
             <artifactId>directory_nav</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.4</version>
         </dependency>
 
         <!-- https://github.com/pwssOrg/PWSS-FileQuarantine/packages/2687320 -->
         <dependency>
             <groupId>lib.pwss</groupId>
             <artifactId>file-quarantine</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.5</version>
         </dependency>
 
 


### PR DESCRIPTION
**PR description**
This PR upgrades three PWSS libraries to their latest patch versions. The upgrade also includes a shared bump of `logback-classic` from **1.5.21** to **1.5.23** across all libraries.

**Changes**

* `algorithm-hash-extraction`: 1.2.5 → 1.2.6
* `directory_nav`: 1.5.3 → 1.5.4
* `file-quarantine`: 1.04 → 1.05


