### PR TITLE
Reset stop scan flag for single scan after canceled full scan

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.pwss</groupId>
     <artifactId>File-Integrity-Scanner</artifactId>
-    <version>1.8.3</version>
+    <version>1.8.4</version>
     <packaging>jar</packaging>
     <description>A File Integrity Scanner</description>
     <licenses>

--- a/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/ScanServiceImpl.java
+++ b/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/ScanServiceImpl.java
@@ -300,6 +300,8 @@ public class ScanServiceImpl extends PWSSbaseService<ScanRepository, Scan, Integ
             throw new ScanAlreadyRunningException();
         }
 
+        stopRequested = false; // Reset stop request at the start of a new scan.
+
         if (validateRequest(request)) {
 
             isFileListToBigForLiveFeed = false;


### PR DESCRIPTION
---

### 🐛 Fix: Reset Stop Scan flag for single scans

**Description**
When a full scan is started and then canceled, the *Stop Scan* flag remains active.
While this does not affect subsequent full scans (the flag is reset during initialization), it causes **single scans to fail** because the flag is not reset in the single scan logic.

**What’s changed**

* Added logic to reset the *Stop Scan* flag when initiating a single scan
* Ensures single scans work correctly after a canceled full scan

**Why**
Prevents unexpected failures when running single scans after canceling a full scan and makes scan behavior consistent.

**Related ticket**

* Bug: Stop Scan Flag Not Reset After Canceled Full Scan

---
