### PR TITLE
Scan speed improvement

### DIFF
--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.pwss</groupId>
     <artifactId>File-Integrity-Scanner</artifactId>
-    <version>1.8.5</version>
+    <version>1.9</version>
     <packaging>jar</packaging>
     <description>A File Integrity Scanner</description>
     <licenses>

--- a/File-Integrity-Scanner/pom.xml
+++ b/File-Integrity-Scanner/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>io.github.pwssorg</groupId>
             <artifactId>algorithm-hash-extraction</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.9</version>
         </dependency>
 
 

--- a/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/FileHashComputer.java
+++ b/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/FileHashComputer.java
@@ -4,7 +4,6 @@ import lib.pwss.hash.file_hash_handler.BigFileHashHandler;
 import lib.pwss.hash.file_hash_handler.FileHashHandler;
 import lib.pwss.hash.file_hash_handler.parallel.ParallelFileHashHandler;
 import lib.pwss.hash.FileHash;
-import lib.pwss.hash.ParallelFileHash;
 import lib.pwss.hash.compare.util.HashCompareUtil;
 import lib.pwss.hash.model.HashForFilesOutput;
 

--- a/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/FileHashComputer.java
+++ b/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/FileHashComputer.java
@@ -2,7 +2,9 @@ package org.pwss.file_integrity_scanner.dsr.service.file_integrity_scanner.scan;
 
 import lib.pwss.hash.file_hash_handler.BigFileHashHandler;
 import lib.pwss.hash.file_hash_handler.FileHashHandler;
+import lib.pwss.hash.file_hash_handler.parallel.ParallelFileHashHandler;
 import lib.pwss.hash.FileHash;
+import lib.pwss.hash.ParallelFileHash;
 import lib.pwss.hash.compare.util.HashCompareUtil;
 import lib.pwss.hash.model.HashForFilesOutput;
 
@@ -29,11 +31,20 @@ final class FileHashComputer {
 
     private final org.slf4j.Logger log;
 
-    // Instance of FileHashHandler for computing hashes of smaller files
+    /**
+     * Instance of FileHashHandler for computing hashes of smaller files
+     */
     private final FileHash fileHashHandler;
 
-    // Instance of BigFileHashHandler for computing hashes of larger files
+    /**
+     * Instance of BigFileHashHandler for computing hashes of larger files
+     */
     private final BigFileHashHandler bigFileHashHandler;
+
+    /**
+     * Handles parallel hash computation for files during scans.
+     */
+    private ParallelFileHashHandler parallelFileHashHandler;
 
     FileHashComputer() {
         this.log = org.slf4j.LoggerFactory.getLogger(FileHashComputer.class);
@@ -54,13 +65,13 @@ final class FileHashComputer {
         try {
 
             if (file.length() > MEMORY_STRATEGY_LIMIT)
-                return Optional.of(bigFileHashHandler.GetAllHashes(file));
+                return Optional.of(parallelFileHashHandler.GetAllHashesInParallel(file));
             else
                 return Optional.of(fileHashHandler.GetAllHashes(file));
 
         } catch (OutOfMemoryError outOfMemoryError) {
-            log.debug("OutOfMemoryError occurred, switching to BigFileHashHandler for file: {}", file.getPath());
-            return Optional.of(bigFileHashHandler.GetAllHashes(file));
+            log.debug("OutOfMemoryError occurred, switching to ParallelFileHashHandler for file: {}", file.getPath());
+            return Optional.of(parallelFileHashHandler.GetAllHashesInParallel(file));
         }
 
         catch (NullPointerException nullPointerException) {
@@ -101,7 +112,24 @@ final class FileHashComputer {
      *                            user.
      */
     final void setUserDefinedMaxLimitInHashComputer(long userDefinedMaxLimit) {
-        bigFileHashHandler.setUserDefinedMaxLimit(userDefinedMaxLimit);
+        this.bigFileHashHandler.setUserDefinedMaxLimit(userDefinedMaxLimit);
+    }
+
+    /**
+     * Shuts down resources used for parallel hash computation.
+     */
+    final void shutdownParallelHashProcessor() {
+
+        this.parallelFileHashHandler.shutdownThreadPool();
+    }
+
+    /**
+     * Initializes resources required for parallel hash computation
+     * before starting a scan operation.
+     */
+    final void initializeParallelHashing() {
+
+        this.parallelFileHashHandler = new ParallelFileHashHandler(bigFileHashHandler);
     }
 
 }

--- a/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/ScanServiceImpl.java
+++ b/File-Integrity-Scanner/src/main/java/org/pwss/file_integrity_scanner/dsr/service/file_integrity_scanner/scan/ScanServiceImpl.java
@@ -268,7 +268,7 @@ public class ScanServiceImpl extends PWSSbaseService<ScanRepository, Scan, Integ
                     Scan scan = new Scan(time, ScanStatus.IN_PROGRESS.toString(), dir, note, isBaseLineScan);
 
                     repository.save(scan);
-
+                    fileHashComputer.initializeParallelHashing();
                     fileTraverser = new FileTraverserImpl();
                     Future<List<File>> futureFiles;
 
@@ -353,7 +353,7 @@ public class ScanServiceImpl extends PWSSbaseService<ScanRepository, Scan, Integ
 
             this.isScanRunning = true;
             log.debug("Scan is running - {}", isScanRunning);
-
+            fileHashComputer.initializeParallelHashing();
             fileTraverser = new FileTraverserImpl();
 
             final Time time = new Time(OffsetDateTime.now(), OffsetDateTime.now());
@@ -594,7 +594,8 @@ public class ScanServiceImpl extends PWSSbaseService<ScanRepository, Scan, Integ
 
                     // Shutdown the file traverser thread pool
                     fileTraverser.shutdownThreadPool();
-
+                    // Shutdown the parallel hash calculation thread pool
+                    fileHashComputer.shutdownParallelHashProcessor();
                     // Set state boolean to false so this method can be ran again
                     this.isScanRunning = false;
                 }

--- a/File-Integrity-Scanner/src/main/resources/logback.xml
+++ b/File-Integrity-Scanner/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
     <!-- Configure specific packages from dependencies -->
     <logger name="org.pwss.io_file" level="INFO"/>
     <logger name="lib.pwss.hash.file_hash_handler" level="ERROR"/>
-    <logger name="lib.pwss.hash.file_hash_handler.parallel" level="DEBUG"/>
+    <logger name="lib.pwss.hash.file_hash_handler.parallel" level="ERROR"/>
     <logger name="org.pwss.util.PWSSDirectoryNavUtil" level="INFO"/>
     <logger name="org.pwss.quarantineManager_aes" level="INFO"/>
     <logger name="org.hibernate" level="INFO"/>

--- a/File-Integrity-Scanner/src/main/resources/logback.xml
+++ b/File-Integrity-Scanner/src/main/resources/logback.xml
@@ -17,6 +17,7 @@
     <!-- Configure specific packages from dependencies -->
     <logger name="org.pwss.io_file" level="INFO"/>
     <logger name="lib.pwss.hash.file_hash_handler" level="ERROR"/>
+    <logger name="lib.pwss.hash.file_hash_handler.parallel" level="DEBUG"/>
     <logger name="org.pwss.util.PWSSDirectoryNavUtil" level="INFO"/>
     <logger name="org.pwss.quarantineManager_aes" level="INFO"/>
     <logger name="org.hibernate" level="INFO"/>


### PR DESCRIPTION
This pull request introduces parallel hash computation to improve performance when scanning large files in the File Integrity Scanner. The main changes include integrating a new `ParallelFileHashHandler`, updating the hash computation logic to use parallel processing for large files, and ensuring proper initialization and shutdown of parallel resources during scan operations.

**Parallel hash computation integration:**

* Added `ParallelFileHashHandler` to `FileHashComputer`, with logic to use it for large files and on out-of-memory errors, replacing previous single-threaded handling. [[1]](diffhunk://#diff-23b05d18a19050681a110b3788183f6b0cb0c692f752ad064ac69d2fd99e77ecR5) [[2]](diffhunk://#diff-23b05d18a19050681a110b3788183f6b0cb0c692f752ad064ac69d2fd99e77ecL32-R47) [[3]](diffhunk://#diff-23b05d18a19050681a110b3788183f6b0cb0c692f752ad064ac69d2fd99e77ecL57-R73)
* Implemented initialization (`initializeParallelHashing`) and shutdown (`shutdownParallelHashProcessor`) methods for parallel hash resources in `FileHashComputer`.

**Scan workflow updates:**

* Updated `ScanServiceImpl` to initialize parallel hashing before scans and shut down parallel hash resources after scans complete. [[1]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fL271-R271) [[2]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fL356-R356) [[3]](diffhunk://#diff-edfd39b91db5089b93602a7e35c1efb1afa0c6705c666abd3056631b3ef9372fL597-R598)

**Dependency and configuration updates:**

* Bumped `algorithm-hash-extraction` dependency version to `1.2.9` and updated project version to `1.9` in `pom.xml`. [[1]](diffhunk://#diff-c5df2d0aa374a76aed7c0e17f74c401113faa208ba5642c833222d3c05ca18f4L10-R10) [[2]](diffhunk://#diff-c5df2d0aa374a76aed7c0e17f74c401113faa208ba5642c833222d3c05ca18f4L143-R143)
* Added a logger configuration for `lib.pwss.hash.file_hash_handler.parallel` in `logback.xml` to control logging from the new parallel handler.